### PR TITLE
회원정보 저장소에서 저장된 회원 ID 전부 조회 기능 추가(#16)

### DIFF
--- a/src/main/java/com/ohgiraffers/Member/MemberRepository.java
+++ b/src/main/java/com/ohgiraffers/Member/MemberRepository.java
@@ -41,8 +41,22 @@ public class MemberRepository {
         values()는 map이 가지고 있는 value를 Collection 형태로 반환
         value 값만 얻을 수 있다
      */
+
+    // 회원의 객체가 리스트로 반환
     public List<MemberDTO> findAll() {
         return new ArrayList<>(store.values());
+    }
+
+
+    // 회원의 ID가 리스트로 반환
+    public List<String> findAllId() {
+        List<MemberDTO> memberDTO = new ArrayList<>(store.values());
+        List<String> memberIdList = new ArrayList<String>();
+
+        for (MemberDTO member : memberDTO) {
+            memberIdList.add(member.getId());
+        }
+        return memberIdList;
     }
 
     // 테스트에서만 사용

--- a/src/test/java/com/ohgiraffers/Member/MemberRepositoryTest.java
+++ b/src/test/java/com/ohgiraffers/Member/MemberRepositoryTest.java
@@ -70,4 +70,36 @@ public class MemberRepositoryTest {
         List<MemberDTO> result = memberRepository.findAll();
         Assertions.assertEquals(2, result.size());
     }
+
+    @DisplayName("임의로 멤버 2명을 생성 후 저장하고, 생성한 멤버의 ID와 저장한 멤버의 ID가 모두 맞게 나오는지 확인")
+    @Test
+    void findAllId() throws ParseException {
+        // 문자열
+        String member1DateStr = "2023-06-01";
+        String member2DateStr = "2003-05-30";
+        // 포맷터
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        // 문자열 -> Date
+        Date member1date = formatter.parse(member1DateStr);
+        Date member2date = formatter.parse(member2DateStr);
+
+
+        //given
+        MemberDTO member1 = new MemberDTO("member1Name", "member1Id", "member1Pwd", member1date);
+        MemberDTO member2 = new MemberDTO("member2Name", "member2Id", "member2Pwd", member2date);
+
+        //when
+        MemberDTO savedMember1 = memberRepository.save(member1);
+        MemberDTO savedMember2 = memberRepository.save(member2);
+
+        //then
+        List<String> result = memberRepository.findAllId();
+
+        // 2명이 맞게 저장되었는지 확인
+        Assertions.assertEquals(2, result.size());
+
+        // 생성한 멤버 Id와 저장한 멤버 Id가 같은지 확인
+        Assertions.assertEquals("member1Id", result.get(0));
+        Assertions.assertEquals("member2Id", result.get(1));
+    }
 }


### PR DESCRIPTION
## 1. 설계한 기능
---
* (1)  findAllId 메소드 호출 시 저장된 회원 ID가 전부 List으로 반환됨

## 2. 주요 패키지, 코드 변화 사항
---
> CheckMemberId 클래스: 처음 스트링을 받은 이후 finalAllId 메소드를 호출하면 이 메소드는 리스트로 반환, 그럼 for문에서 리스트 인덱스별로 빼가지고 처음 스트링과 비교하는 로직이 있어야 할 것 같다고 생각
